### PR TITLE
Replace gnomad rsids with dbsnp

### DIFF
--- a/wdl/meta.json
+++ b/wdl/meta.json
@@ -8,7 +8,7 @@
     "meta_analysis.run_meta.gather.loglog_ylim": 20,
     "meta_analysis.run_meta.gather.docker": "gcr.io/covid-19-hg/saige:0.36.3.2-2",
     "meta_analysis.run_meta.add_rsids_af.docker": "gcr.io/covid-19-hg/meta:f053b",
-    "meta_analysis.run_meta.add_rsids_af.file_ref": "gs://covid19-hg-analysis/gnomad/v3/gnomad_v3_b38_ref_all.rsid.gz",
+    "meta_analysis.run_meta.add_rsids_af.file_ref": "gs://covid19-hg-analysis/dbsnp/dbsnp_hg38p13_b153_numerical.vcf.gz",
     "meta_analysis.run_meta.add_rsids_af.p_thresh": 1e-5,
     "meta_analysis.run_meta.filter_cols.docker": "gcr.io/covid-19-hg/saige:0.36.3.2-2",
     "meta_analysis.run_meta.filter_cols.out_template": "COVID19_HGI_{PHENO}_20200805.txt.gz",

--- a/wdl/meta.sub.wdl
+++ b/wdl/meta.sub.wdl
@@ -121,7 +121,7 @@ task add_rsids_af {
 
         import gzip, numpy
 
-        fp_ref = gzip.open('${ref_file}', 'rt')
+        fp_ref = gzip.open('${file_ref}', 'rt')
         ref_has_lines = True
         ref_chr = 1
         ref_pos = 0

--- a/wdl/meta.sub.wdl
+++ b/wdl/meta.sub.wdl
@@ -171,7 +171,7 @@ task add_rsids_af {
 
                 rsid = 'NA'
                 for r in ref_vars:
-                    if r[ref_h_idx['REF']] == ref and r[ref_h_idx['ALT']] == alt:
+                    if r[ref_h_idx['REF']] == ref and alt in r[ref_h_idx['ALT']].split(','):
                         rsid = r[ref_h_idx['ID']]
                         break
 


### PR DESCRIPTION
Switched gnomad reference to dbsnp vcf in `add_rsids_af` task.